### PR TITLE
Slider control width minimized

### DIFF
--- a/stylesheets/ss.css
+++ b/stylesheets/ss.css
@@ -21,7 +21,7 @@ svg {
   z-index: 2;
   position: absolute;
   top: 0;
-  width: 12%;
+  width: 6%;
   height: 100%;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;


### PR DESCRIPTION
When second slide image comes then the left slider control gets activated. Since its width is 12% so it is get overlapped with the links which are there in slider content. See this in image (The highlighted block is of slider control left): 
![screenshot from 2015-12-28 15 28 18](https://cloud.githubusercontent.com/assets/9320644/12017013/aaa5ab48-ad77-11e5-9da0-3ca069dd8c3c.png)

So I did minimized to 6% so that the link gets activated when we hover it there.
Updated image:
