### PR TITLE
Fixed id contributors 

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,10 +300,10 @@
 
 
         </div>
-        <a class="anchor" name="contributors"></a>
+        <a class="anchor" name="contributors" id="contributors"></a>
         <div class="row contributors-wrapper">
           <div class="members contributers">
-            <h1 class="section-h1" id="contributors"><span class="white-border">Contributors</span></h1>
+            <h1 class="section-h1"><span class="white-border">Contributors</span></h1>
           </div>
         </div>
         <div class="row thanku-wrapper text-scroll scrolling-words otto" align="center" >

--- a/js/index.js
+++ b/js/index.js
@@ -202,14 +202,13 @@ $(document).ready(function() {
     for (var i = 0; i <= json.length - 1; i++) {
       output = output + '<div class="col-xs-4 col-sm-4 col-md-4 col-lg-3">\n';
       output = output + '<div class="card">\n';
+      output = output + '<a href="https://github.com/' + json[i].login + '">';
       output = output + '<div class="avatar img-circle">\n';
       output = output + '<img class="card-img-top" src="" data="https://avatars.githubusercontent.com/u/' + json[i].id + '?v=3" alt="' + json[i].login + '">\n';
       output = output + '</div>';
       output = output + '<div class="card-block">';
       output = output + '<h4 class="card-title">' + json[i].login + '</h4>';
-      output = output + '<div class="social">';
-      output = output + '<a href="https://github.com/' + json[i].login + '"><i id="github" class="icon-github"></i></a>';
-      output = output + '</div>';
+      output = output + '</a>';
       output = output + '</div>';
       output = output + '</div>';
       output = output + '</div>';


### PR DESCRIPTION
Whenever we click to mentors link in header menu then it scroll down to move at mentors section where we see mentors head word written on it. As shows in image and it does same with students link but whenever we click on contributors link then it do scroll down but then contributors head word doesn't show and it get leave behind. As shown in image.
![screenshot from 2015-12-28 16 05 09](https://cloud.githubusercontent.com/assets/9320644/12017499/7550e164-ad7d-11e5-8901-f47dec060a61.png)
![screenshot from 2015-12-28 16 05 24](https://cloud.githubusercontent.com/assets/9320644/12017524/b54a1998-ad7d-11e5-93df-8efc1d2a0416.png)
![screenshot from 2015-12-28 16 05 38](https://cloud.githubusercontent.com/assets/9320644/12017533/da02e576-ad7d-11e5-8c04-fd401514e6dc.png)
##### So here is the updated image. I removed that contributor id and replaced it.

![screenshot from 2015-12-28 16 07 33](https://cloud.githubusercontent.com/assets/9320644/12017535/f249d5e0-ad7d-11e5-9505-67fb40600f31.png)
