### PR TITLE
Fix #262; Force card titles on one line

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -338,6 +338,9 @@ a:hover {
 .card .card-title {
   color: white;
   text-align: center;
+  white-space: nowrap;
+  margin-left: -10px;
+  margin-right: -10px;
 }
 .card a:hover, a:focus {
   text-decoration: none;


### PR DESCRIPTION
Force card titles on one line to keep column height, so that columns in students section flow without empty spaces
