### PR TITLE
GitHub/Twitter/Facebook/Blog icons Fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
   <link rel="stylesheet" type="text/css" href="stylesheets/scroll.css" media="screen">
   <link rel="stylesheet" type="text/css" href="stylesheets/hover.css" media="screen">
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css">
   <link rel="stylesheet" type="text/css" href="stylesheets/component.css">
 </head>
 <body>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -341,6 +341,7 @@ a:hover {
   white-space: nowrap;
   margin-left: -10px;
   margin-right: -10px;
+  overflow: hidden;
 }
 .card a:hover, a:focus {
   text-decoration: none;


### PR DESCRIPTION
At this [commit](https://github.com/shashank-sharma/gci15.fossasia.org/commit/cef7378bd19d5f3c53569fdd389aa3c14b740fd6) which was made 2 days ago the real problem started where the icons where not showing at all. That commit title is : Minify 3rd party CSS sheets  where the stylesheet css link was changed to something new which was creating problem. I replaced it with the original link and now its working fine. 
![screenshot from 2016-01-03 00 35 52](https://cloud.githubusercontent.com/assets/9320644/12075778/ff13b4b6-b1b1-11e5-8586-720d550b06b1.png)
