### PR TITLE
Increased Number of contributors in a row. closes #396

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -200,7 +200,7 @@ $(document).ready(function() {
   $.getJSON("https://api.github.com/repos/fossasia/gci15.fossasia.org/contributors", function (json) {
     output = "";
     for (var i = 0; i <= json.length - 1; i++) {
-      output = output + '<div class="col-xs-4 col-sm-4 col-md-4 col-lg-3">\n';
+      output = output + '<div class="col-xs-4 col-sm-4 col-md-3 col-lg-2">\n';
       output = output + '<div class="card">\n';
       output = output + '<a href="https://github.com/' + json[i].login + '">';
       output = output + '<div class="avatar img-circle">\n';


### PR DESCRIPTION
Only the first 30 most-active contributors are being listed. GitHub caps the API result to 30 entries so we can not display all 70+ contributors here.
