### PR TITLE
Update font size of project list

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1031,6 +1031,7 @@ li:hover ul {
     display: block;
     padding: 10px 15px;
     color: #706F6F;
+    font-size: 15px;
 }
 #projlist li a:hover{
     background-color: #EEEEEE;


### PR DESCRIPTION
Edit font size of project list as "Geolocation projects" text was going out of that div. I though of hidding it so that the text font size will be the same but that was not looking good and I also tried making it to go to the new line but that was also not looking good. So at last I simply changed the font size. (As shown in image) : 
Original : 
![screenshot from 2016-01-17 16 07 24](https://cloud.githubusercontent.com/assets/9320644/12377061/fe1ead2a-bd34-11e5-8164-24087e8bb849.png)

Edited : 
![screenshot from 2016-01-17 16 08 00](https://cloud.githubusercontent.com/assets/9320644/12377060/fe178da6-bd34-11e5-8cdb-a0598982e1fa.png)
