### PR TITLE
Edit alt tag names in students game section

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,7 +560,7 @@
                   <div class="card">
                     <a href="https://github.com/oanarosca/hangman/tree/gh-pages">
                       <div class="avatar img-circle">
-                        <img class="card-img-top" src="img/gallery/hangman1.png" data="img/gallery/hangman1.png" alt="shashank-sharma">
+                        <img class="card-img-top" src="img/gallery/hangman1.png" data="img/gallery/hangman1.png" alt="oanarosca">
                       </div>
                     </a>
                   </div>
@@ -576,7 +576,7 @@
                   <div class="card">
                     <a href="https://github.com/Juanvulcano/GCI/tree/master/Fossasia/Week3">
                       <div class="avatar img-circle">
-                        <img class="card-img-top" src="img/gallery/Treasurehunt.png" data="img/gallery/Treasurehunt.png" alt="yasoob-khalid">
+                        <img class="card-img-top" src="img/gallery/Treasurehunt.png" data="img/gallery/Treasurehunt.png" alt="Juanvulcano">
                       </div>
                     </a>
                   </div>
@@ -592,7 +592,7 @@
                   <div class="card">
                     <a href="https://yasoob.me/checkers">
                       <div class="avatar img-circle">
-                        <img class="card-img-top" src="img/gallery/checkers1.png" data="img/gallery/checkers1.png" alt="shashank-sharma">
+                        <img class="card-img-top" src="img/gallery/checkers1.png" data="img/gallery/checkers1.png" alt="yasoob-khalid">
                       </div>
                     </a>
                   </div>


### PR DESCRIPTION
I guess I am getting in too detail here but in student section I am seeing my name in alt tag but I haven't done anything related to that project. Means if image was not able to load then my name will be shown which are not supposed to be there because I never contributed in that project. (same scenario with other names too). See image below. I replaced it with the name of original creator.

![screenshot from 2016-01-17 19 45 19](https://cloud.githubusercontent.com/assets/9320644/12377917/c7a5e62c-bd53-11e5-970b-f8d9aaa19376.png)
