### PR TITLE
Slider indicators now show properly closes #625

### DIFF
--- a/index.html
+++ b/index.html
@@ -1132,7 +1132,6 @@
   <script src="js/photostack.js"></script>
   <script src="http://code.angularjs.org/angular-1.0.0rc4.min.js"></script>
   <script src="http://code.angularjs.org/angular-resource-1.0.0rc4.min.js"></script>
-  <script src="js/index.js"></script>
   <script type="text/javascript">
   angular.module('Twitter', ['ngResource']);
   function TwitterCtrl($scope, $resource) {

--- a/js/index.js
+++ b/js/index.js
@@ -21,16 +21,16 @@ $(document).ready(function() {
       autoSlideDelay = 6000,
       $pagination = $(".slider-pagi");
 
-  function createBullets() {
+  (function createBullets() {
     for (var i = 0; i < numOfSlides+1; i++) {
       var $li = $("<li class='slider-pagi__elem'></li>");
       $li.addClass("slider-pagi__elem-"+i).data("page", i);
       if (!i) $li.addClass("active");
+      console.log(i);
       $pagination.append($li);
     }
-  };
+  })();
 
-  createBullets();
 
   function manageControls() {
     $(".slider-control").removeClass("inactive");


### PR DESCRIPTION
Since there are four slides, there are only four circles which closes issue #625. The `index.js` file was being loaded twice.
