### PR TITLE
other links mobile view is aligned center

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -98,3 +98,10 @@ h5{margin-top:30px;}
         width: 350px !important;
     }
 }
+@media (max-width:767px) {
+    .links {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+}


### PR DESCRIPTION
When we view the website in mobile view the other links part is not responsive as it is not properly aligned after this change it will become responsive as it align it to center

before : 

![WhatsApp Image 2021-09-03 at 8 47 42 PM](https://user-images.githubusercontent.com/75080333/132029790-7e7ad7b6-9dfb-463f-857e-540a4e91db3e.jpeg)

after : 
  
![WhatsApp Image 2021-09-03 at 8 47 42 PM](https://user-images.githubusercontent.com/75080333/132030179-aa3edce1-c236-4125-af05-2e421d55dc59.jpg)
